### PR TITLE
Show node_id

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,22 @@
                 </div>
                 <button type="submit" value="Submit" style="margin-left: auto">Color</button>
             </form>
+            <form style="display: flex;flex-direction: column" id="showId">
+                <div style="display: flex;flex-direction: column;margin-bottom: 8px">
+                    <div style="display: flex;margin-bottom: 8px;">
+                        <label for="nodes">Show Node ID</label>
+                        <div id="table-holder" style="overflow-y: auto;height: 120px;">
+                            <table id="nodes-checkbox" style="flex: 1 1 auto;">
+                                <tr>
+                                    <th>NodeID</th>
+                                    <th>Show</th>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" value="Submit" style="margin-left: auto">Apply</button>
+            </form>
             <form style="display: flex; flex-direction: column;" id="environment-form">
                 <div style="display: flex;flex-direction: column;margin-bottom: 8px">
                     <div style="display: flex">

--- a/src/data.ts
+++ b/src/data.ts
@@ -17,7 +17,14 @@ export interface PaintNodeCommand {
     payload: {
         node_id: number,
         color: [number, number, number],
-        show_id: boolean,
+    }
+}
+
+export interface ShowIdCommand {
+    command: "show_id"
+    payload: {
+        node_id: number,
+        show: boolean
     }
 }
 
@@ -35,4 +42,4 @@ export interface ResizeNodesCommand {
     }
 }
 
-export type VisualizationCommand = PaintNodeCommand | PaintEnvironmentCommand | ResizeNodesCommand;
+export type VisualizationCommand = PaintNodeCommand | ShowIdCommand | PaintEnvironmentCommand | ResizeNodesCommand;

--- a/src/data.ts
+++ b/src/data.ts
@@ -20,8 +20,8 @@ export interface PaintNodeCommand {
     }
 }
 
-export interface ShowIdCommand {
-    command: "show_id"
+export interface ShowNodeIdCommand {
+    command: "show_node_id"
     payload: {
         node_id: number,
         show: boolean
@@ -42,4 +42,4 @@ export interface ResizeNodesCommand {
     }
 }
 
-export type VisualizationCommand = PaintNodeCommand | ShowIdCommand | PaintEnvironmentCommand | ResizeNodesCommand;
+export type VisualizationCommand = PaintNodeCommand | ShowNodeIdCommand | PaintEnvironmentCommand | ResizeNodesCommand;

--- a/src/data.ts
+++ b/src/data.ts
@@ -16,7 +16,8 @@ export interface PaintNodeCommand {
     command: "paint_node"
     payload: {
         node_id: number,
-        color: [number, number, number]
+        color: [number, number, number],
+        show_id: boolean,
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
 import {connectToSocket} from "./socket.js"
-import {update, initializeVisualization, finalizeVisualization, executeCommand} from "./visualization.js";
+import {update, finalizeVisualization, executeCommand, initializeThree} from "./visualization.js";
 
 import "../style.css"
 import {InitializationData, SimulationData, VisualizationCommand} from "./data";
-import {initializeInteraction} from "./interaction";
 
 
 function initialize(data: InitializationData) {
-    initializeVisualization(data)
-    initializeInteraction()
+    initializeThree(data)
 }
 
 function updateData(data: SimulationData | VisualizationCommand) {

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -234,24 +234,20 @@ Real time: ${formatTime(data.real_time)}`
 }
 
 export function executeCommand(command: VisualizationCommand) {
-    console.log(command);
     if (command.command === "paint_node") {
-        console.log(command.payload);
-        console.log("paint_node");
-        const {node_id, color, show_id} = command.payload;
+        const {node_id, color} = command.payload;
         const node = nodes[node_id];
         const rgbColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`
         vehicles[node].mesh.material = new THREE.MeshBasicMaterial({ color: rgbColor });
-        if (vehicles[node].text != null) {
-            vehicles[node].text = show_id? vehicles[node].text : null;
-        } else if (show_id){
-            vehicles[node].text = new THREE.Mesh(
-                new TextGeometry(node, {font: font, size: nodeSize * 2, height:1, depth: 0.5}),
-                new THREE.MeshBasicMaterial({ color: 'rgb(0, 0, 0)'})
-            );
-            vehicles[node].text.lookAt( camera.position );
-            scene.add(vehicles[node].text);
-        }
+    } else if (command.command === "show_id") {
+        const {node_id, show} = command.payload;
+        const node = nodes[node_id];
+        vehicles[node].text = show? new THREE.Mesh(
+            new TextGeometry(node, {font: font, size: nodeSize * 2, height:1, depth: 0.5}),
+            new THREE.MeshBasicMaterial({ color: 'rgb(0, 0, 0)'})
+        ) : null;
+        vehicles[node].text.lookAt( camera.position );
+        scene.add(vehicles[node].text);
     } else if (command.command === "paint_environment") {
         const {color} = command.payload;
         scene.background = new THREE.Color(...color)

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -81,12 +81,23 @@ showIdForm.addEventListener("submit", (e) => {
         scene.add(vehicles[node].text);
     });
 
+    const checkedStr = checkedNodes.join(" ");
+    localStorage.setItem("show-id", checkedStr);
 })
+
+function setCheckBox(checked_nodes: string[]) {
+    
+}
 
 function loadStoredConfigs() {
     const bgColor = localStorage.getItem("environment-background-color")
     const nodeSizeStored = localStorage.getItem("environment-node-size")
+    const checkedNodes = localStorage.getItem("show-id")
     nodeSize = nodeSizeStored !== null ? parseFloat(nodeSizeStored) : null
+
+    if (checkedNodes !== null) {
+        const checkboxElements = document.querySelectorAll("input#show-id")
+    }
 
     if (bgColor !== null) {
         scene.background = new THREE.Color(bgColor)
@@ -116,6 +127,7 @@ function getTableRowElement(node: string) {
     check.value = node;
     check.type = 'checkbox';
     check.name = 'nodes-checkbox';
+    check.id = 'show-check'
     check_th.id = "check";
     check_th.appendChild(check);
     tr.appendChild(name_th);

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -257,8 +257,8 @@ export function update(data: SimulationData) {
         vehicles[node].mesh.position.z = pos[1];
 
         if (vehicles[node].text != null) {
-            vehicles[node].text.position.x = pos[0];
-            vehicles[node].text.position.y = pos[2] + (nodeSize * 3);
+            vehicles[node].text.position.x = pos[0] - 5;
+            vehicles[node].text.position.y = pos[2] + (nodeSize * 5);
             vehicles[node].text.position.z = pos[1] + 5;
             vehicles[node].text.lookAt( camera.position )
         }
@@ -287,7 +287,7 @@ export function executeCommand(command: VisualizationCommand) {
         const node = nodes[node_id];
         const rgbColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`
         vehicles[node].mesh.material = new THREE.MeshBasicMaterial({ color: rgbColor });
-    } else if (command.command === "show_id") {
+    } else if (command.command === "show_node_id") {
         console.log(command);
         const {node_id, show} = command.payload;
         const node = nodes[node_id];

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -288,7 +288,6 @@ export function executeCommand(command: VisualizationCommand) {
         const rgbColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`
         vehicles[node].mesh.material = new THREE.MeshBasicMaterial({ color: rgbColor });
     } else if (command.command === "show_node_id") {
-        console.log(command);
         const {node_id, show} = command.payload;
         const node = nodes[node_id];
         vehicles[node].text = show? getTextObject(node) : null;

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -49,8 +49,12 @@ environmentForm.addEventListener("submit", (e) => {
 
     scene.background = new THREE.Color(bgColor)
     
-    for (const vehicle of Object.values(vehicles)) {
+    for (const node of Object.keys(vehicles)) {
+        const vehicle = vehicles[node];
         vehicle.mesh.geometry = new THREE.SphereGeometry(nodeSize, 32, 32);
+        if (vehicle.text != null) {
+            vehicle.text.geometry = new TextGeometry(node, {font: font, size: nodeSize * 2, height:1, depth: 0.5});
+        }
     }
 
     localStorage.setItem("environment-background-color", bgColor)

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -16,7 +16,7 @@ let scene: THREE.Scene = null;
 let renderer: THREE.Renderer = null;
 let camera: THREE.PerspectiveCamera = null;
 let font = null;
-
+let nodeSize = 0.1;
 let resizeEvent: () => void = null;
 
 const statusElement = document.getElementById("status") as HTMLPreElement;
@@ -45,7 +45,7 @@ environmentForm.addEventListener("submit", (e) => {
 
     const formData = new FormData(environmentForm);
     const bgColor = formData.get("background-color") as string
-    const nodeSize = parseFloat(formData.get("node-size") as string)
+    nodeSize = parseFloat(formData.get("node-size") as string)
 
     scene.background = new THREE.Color(bgColor)
     
@@ -60,7 +60,7 @@ environmentForm.addEventListener("submit", (e) => {
 function loadStoredConfigs() {
     const bgColor = localStorage.getItem("environment-background-color")
     const nodeSizeStored = localStorage.getItem("environment-node-size")
-    const nodeSize = nodeSizeStored !== null ? parseFloat(nodeSizeStored) : null
+    nodeSize = nodeSizeStored !== null ? parseFloat(nodeSizeStored) : null
 
     if (bgColor !== null) {
         scene.background = new THREE.Color(bgColor)
@@ -206,7 +206,7 @@ export function update(data: SimulationData) {
 
         if (vehicles[node].text != null) {
             vehicles[node].text.position.x = pos[0];
-            vehicles[node].text.position.y = pos[2] + 10;
+            vehicles[node].text.position.y = pos[2] + (nodeSize * 3);
             vehicles[node].text.position.z = pos[1] + 5;
             vehicles[node].text.lookAt( camera.position )
         }
@@ -242,7 +242,7 @@ export function executeCommand(command: VisualizationCommand) {
             vehicles[node].text = show_id? vehicles[node].text : null;
         } else if (show_id){
             vehicles[node].text = new THREE.Mesh(
-                new TextGeometry(node, {font: font, size: 1, height:1, depth: 0.5}),
+                new TextGeometry(node, {font: font, size: nodeSize * 2, height:1, depth: 0.5}),
                 new THREE.MeshBasicMaterial({ color: 'rgb(0, 0, 0)'})
             );
             vehicles[node].text.lookAt( camera.position );

--- a/style.css
+++ b/style.css
@@ -58,7 +58,18 @@ label {
   margin: 4px;
 }
 
+div#table-holder {
+  border: 0;
+  padding: 8px;
+  background-color: white;
+  box-shadow: 0 3px 1px -2px #0003,0 2px 2px #00000024,0 1px 5px #0000001f;
+  cursor: pointer;
+  font-size: 12px;
+}
 
+td#check {
+  text-align: center;
+}
 /*
 https://github.com/nzbin/three-dots
 


### PR DESCRIPTION
This pull request adds the show_id functionality, available through the show_id parameter in the `paint_node` command.

Summary of changes:
  - A new interface called `NodeInterface` containing both the vehicle mesh and the text mesh. 
  - `vehicles` variable type change from `THREE.Mesh` to `NodeInterface[]`
  - Property `show_id` added to `paint_node` command
  - `TextGeometry` logic added to: initialization of the visualization; processing of `paint_node` command; frame updates.
  - A UI element allowing the user to toggle show_node_id through the visualization
  - LocalStorage backup for UI defined show_node_id 
Preview:
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/ef71b6d9-1a61-45ae-bc1d-b1a37054d142">

Improvements:
  - The text is not centralized depending of the camera position as you can notice in the image below
<img width="265" alt="image" src="https://github.com/user-attachments/assets/8a92e687-4f2e-4162-b768-691cc78e2d9d">
  
Solving this issue is not trivial, so a special branch called `centralized_text` was created to address this.
  - Adding a form UI allowing the user to change nodes show_id property.